### PR TITLE
Let elasticsearch version be configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+elasticsearch_repo: "deb http://packages.elastic.co/elasticsearch/2.x/debian stable main"
+elasticsearch_package: "elasticsearch"
 elasticsearch_network_host: localhost
 elasticsearch_http_port: 9200
 elasticsearch_script_inline: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,14 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: open ElasticSearch http port on the firewall
+  ufw:
+    rule: allow
+    port: "{{ item }}"
+    proto: tcp
+  with_items:
+    - "{{ elasticsearch_http_port }}"
+
 - name: Configure Elasticsearch.
   template:
     src: elasticsearch.yml.j2

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -6,9 +6,9 @@
 
 - name: Add Elasticsearch repository.
   apt_repository:
-    repo: 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main'
+    repo: '{{ elasticsearch_repo }}'
     state: present
     update_cache: yes
 
 - name: Install Elasticsearch.
-  apt: pkg=elasticsearch state=present
+  apt: pkg="{{ elasticsearch_package }}" state=present


### PR DESCRIPTION
Pulls the elasticsearch repo and version from variables instead of hard-coding them in the task.

Also allows ingress from the ES port.