### PR TITLE
Set up a reverse proxy in front of Elasticsearch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Whether to configure a reverse proxy (nginx) in front of Elasticsearch. This is 
 
 Which port the reverse proxy should listen on to forward authenticated requests to Elasticsearch.
 
-    reverse_proxy_auth_file: "/etc/nginx/.passwd"
+    reverse_proxy_auth_file: "/etc/nginx/.elasticsearch.passwd"
 
 The location of the auth credentials file the role generates and uses.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ The port to listen for HTTP connections on.
 
 Whether to allow inline scripting against ElasticSearch. You should read the following link as there are possible security implications for enabling these options: [Enable Dynamic Scripting](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html#enable-dynamic-scripting). Available options include: `true`, `false`, and `sandbox`.
 
+    ENABLE_REVERSE_PROXY: false
+
+Whether to configure a reverse proxy (nginx) in front of Elasticsearch. This is useful if you need to connect securely through the public internet.
+
+    reverse_proxy_listen_port: 9201
+
+Which port the reverse proxy should listen on to forward authenticated requests to Elasticsearch.
+
+    reverse_proxy_auth_file: "/etc/nginx/.passwd"
+
+The location of the auth credentials file the role generates and uses.
+
+    reverse_proxy_auth_username: admin
+    reverse_proxy_auth_password: admin
+
+The username and password needed to authenticate to Elasticsearch. **You should set this explicitly in production**.
+
 ## Dependencies
 
   - geerlingguy.java

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,6 @@ elasticsearch_log_dir: "/var/log/elasticsearch"
 
 ENABLE_REVERSE_PROXY: false
 reverse_proxy_listen_port: 9201
-reverse_proxy_auth_file: "/etc/nginx/.passwd"
+reverse_proxy_auth_file: "/etc/nginx/.elasticsearch.passwd"
 reverse_proxy_auth_username: "admin"
 reverse_proxy_auth_password: "admin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,9 @@ elasticsearch_script_indexed: true
 elasticsearch_data_dir: "/usr/share/elasticsearch/data"
 elasticsearch_cfg_dir: "/usr/share/elasticsearch/config"
 elasticsearch_log_dir: "/var/log/elasticsearch"
+
+ENABLE_REVERSE_PROXY: false
+reverse_proxy_listen_port: 9201
+reverse_proxy_auth_file: "/etc/nginx/.passwd"
+reverse_proxy_auth_username: "admin"
+reverse_proxy_auth_password: "admin"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,8 @@
 ---
 - name: restart elasticsearch
   service: name=elasticsearch state=restarted
+
+- name: restart nginx
+  service:
+    name: nginx
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,3 +41,6 @@
 
 - name: Make sure Elasticsearch is running before proceeding.
   wait_for: host={{ elasticsearch_network_host }} port={{ elasticsearch_http_port }} delay=3 timeout=300
+
+- include: reverse-proxy.yml
+  when: ENABLE_REVERSE_PROXY

--- a/tasks/reverse-proxy.yml
+++ b/tasks/reverse-proxy.yml
@@ -1,0 +1,20 @@
+- name: Create password file for authenticating through nginx
+  command: printf "{{ reverse_proxy_auth_username }}:$(openssl passwd -crypt {{ reverse_proxy_auth_password }})n" > {{ reverse_proxy_auth_file }}
+
+- name: Copy nginx site configuration
+  template:
+    src: elasticsearch-nginx.j2
+    dest: /etc/nginx/sites-available/elasticsearch
+
+- name: Enable nginx site configuration
+  file:
+    src: /etc/nginx/sites-available/elasticsearch
+    dest: /etc/nginx/sites-enabled/elasticsearch
+    state: link
+  notify: restart nginx
+
+- name: Open nginx's listen port for reverse proxying to Elasticsearch on the firewall
+  ufw:
+    rule: allow
+    port: {{ nginx_listen_port }}
+    proto: tcp

--- a/templates/elasticsearch-nginx.j2
+++ b/templates/elasticsearch-nginx.j2
@@ -13,6 +13,9 @@ http {
     auth_basic "Protected Elasticsearch";
     auth_basic_user_file {{ reverse_proxy_auth_file }};
 
+    access_log /var/log/nginx/elasticsearch/nginx.access.log;
+    error_log /var/log/nginx/elasticsearch/nginx.error.log;
+
     location / {
       proxy_pass http://elasticsearch;
       proxy_redirect off;

--- a/templates/elasticsearch-nginx.j2
+++ b/templates/elasticsearch-nginx.j2
@@ -1,0 +1,21 @@
+events {
+  worker_connections 10000;
+}
+
+http {
+  upstream elasticsearch {
+    server {{ elasticsearch_network_host }}:{{ elasticsearch_http_port }};
+  }
+
+  server {
+    listen {{ nginx_listen_port }};
+
+    auth_basic "Protected Elasticsearch";
+    auth_basic_user_file {{ reverse_proxy_auth_file }};
+
+    location / {
+      proxy_pass http://elasticsearch;
+      proxy_redirect off;
+    }
+  }
+}


### PR DESCRIPTION
Needed for authenticated connections when security groups/VPN are not available.

This work is a part of implementing a proper distributed log collection scheme.